### PR TITLE
Add GATEWAY_IP6 variable

### DIFF
--- a/usr/libexec/helper-scripts/settings_echo
+++ b/usr/libexec/helper-scripts/settings_echo
@@ -12,4 +12,5 @@ check_tor_bootstrap_helper_variables
 
 echo "\
 GATEWAY_IP=\"$GATEWAY_IP\"
+GATEWAY_IP6=\"$GATEWAY_IP6\"
 gateway_control_port=\"$gateway_control_port\""

--- a/usr/libexec/helper-scripts/tor_bootstrap_check.bsh
+++ b/usr/libexec/helper-scripts/tor_bootstrap_check.bsh
@@ -12,6 +12,11 @@ check_tor_bootstrap_helper_variables() {
             qubesdb_read_qubes_gateway_result="$(qubesdb-read /qubes-gateway 2>/dev/null)" || { gateway_ip_error="qubesdb_read_failed" ; qubesdb_read_qubes_gateway_result="127.0.0.1" ; };
             GATEWAY_IP="$qubesdb_read_qubes_gateway_result"
          fi
+         if [ "$GATEWAY_IP6" = "" ]; then
+            gateway_ip_error=""
+            qubesdb_read_qubes_gateway_result="$(qubesdb-read /qubes-gateway6 2>/dev/null)" || { gateway_ip_error="qubesdb_read_failed" ; qubesdb_read_qubes_gateway_result="::1" ; };
+            GATEWAY_IP6="$qubesdb_read_qubes_gateway_result"
+         fi
          if [ "$gateway_control_port" = "" ]; then
             gateway_control_port="9051"
          fi
@@ -43,6 +48,10 @@ check_tor_bootstrap_helper_variables() {
          ## PROXY_IP="10.152.152.10"
          GATEWAY_IP="10.152.152.10"
       fi
+      if [ "$GATEWAY_IP6" = "" ]; then
+         ## IP HARDCODED. See above comment
+         GATEWAY_IP6="fd19:c33d:88bc::10"
+      fi
       if [ "$gateway_control_port" = "" ]; then
          gateway_control_port="9051"
       fi
@@ -52,6 +61,9 @@ check_tor_bootstrap_helper_variables() {
       if [ "$GATEWAY_IP" = "" ]; then
          GATEWAY_IP="127.0.0.1"
       fi
+      if [ "$GATEWAY_IP6" = "" ]; then
+         GATEWAY_IP6="::1"
+      fi
    fi
 
    if [ "$gateway_control_port" = "" ]; then
@@ -59,6 +71,9 @@ check_tor_bootstrap_helper_variables() {
    fi
    if [ "$GATEWAY_IP" = "" ]; then
       GATEWAY_IP="127.0.0.1"
+   fi
+   if [ "$GATEWAY_IP6" = "" ]; then
+      GATEWAY_IP6="::1"
    fi
 }
 


### PR DESCRIPTION
This pull request adds an IPv6 gateway configuration variable

## Mandatory Checklist

- [X] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
