### PR TITLE
Fix NO_COLOR environment variable check to match spec

### DIFF
--- a/usr/lib/python3/dist-packages/unicode_show/tests/unicode_show.py
+++ b/usr/lib/python3/dist-packages/unicode_show/tests/unicode_show.py
@@ -480,7 +480,7 @@ FILENAME_PLACEHOLDER:1: Hello world![U+0009][U+0020]
         self._test_stdin_pty(
             main_func=unicode_show_main,
             argv0=self.argv0,
-            stdout_string=expect_string_color,
+            stdout_string=expect_string_nocolor,
             exit_code=1,
             args=[],
             stdin_string=test_string,

--- a/usr/lib/python3/dist-packages/unicode_show/unicode_show.py
+++ b/usr/lib/python3/dist-packages/unicode_show/unicode_show.py
@@ -174,7 +174,7 @@ def main() -> int:
     global USE_COLOR
     USE_COLOR = (
         not os.getenv("NOCOLOR")
-        and os.getenv("NO_COLOR") != "1"
+        and os.getenv("NO_COLOR") is None
         and os.getenv("TERM") != "dumb"
         and sys.stdout.isatty()
     )


### PR DESCRIPTION
This PR fixes the NO_COLOR environment variable handling to comply with the NO_COLOR specification.

## Summary
The NO_COLOR specification states that the presence of the NO_COLOR environment variable (regardless of its value) should disable color output. The current implementation incorrectly checked if the variable equals "1", which doesn't match the spec.

## Changes
- **unicode_show.py**: Changed `os.getenv("NO_COLOR") != "1"` to `os.getenv("NO_COLOR") is None` to properly detect when the NO_COLOR variable is set (spec-compliant behavior)
- **tests/unicode_show.py**: Updated the corresponding test case to expect no color output (`expect_string_nocolor`) instead of colored output (`expect_string_color`) when testing PTY behavior, aligning the test with the corrected implementation

## Implementation Details
The NO_COLOR specification requires that color output be disabled whenever the NO_COLOR environment variable is present, regardless of its value. The fix changes the logic to check if the variable is `None` (not set) rather than checking for a specific value, ensuring compliance with the standard.

https://claude.ai/code/session_01Rq3JHKjsKVPhhn8QFPQAnf