### PR TITLE
Add sanitize-string to test linting utilities

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -25,7 +25,7 @@ done
 stdin_file_read_utils=(stcat stcatn)
 stdin_implicit_read_utils=(sttee stsponge strip-markup unicode-show)
 stdin_utils=("${stdin_file_read_utils[@]}" "${stdin_implicit_read_utils[@]}")
-utils=(stprint stecho "${stdin_utils[@]}")
+utils=(stprint stecho sanitize-string "${stdin_utils[@]}")
 cd "${git_toplevel}/usr/bin"
 "${black[@]}" -- "${utils[@]}"
 "${pylint[@]}" -- "${utils[@]}"


### PR DESCRIPTION
This change adds the `sanitize-string` utility to the list of Python utilities that are checked by the black formatter and pylint linter in the test suite.

**Key changes:**
- Added `sanitize-string` to the `utils` array in the `run-tests` script, positioning it between `stecho` and the stdin utilities

**Details:**
The `sanitize-string` utility is now included in the automated code quality checks (black formatting and pylint linting) that are run against all utilities in the `usr/bin` directory. This ensures the utility maintains consistent code style and quality standards alongside the other utilities in the project.

https://claude.ai/code/session_01MiP7srAcMmdrTjM53kwr3j