### PR TITLE
Fix incorrect comments and add missing exit code in test script

### DIFF
--- a/unicode-testscript
+++ b/unicode-testscript
@@ -58,23 +58,23 @@ process_file() {
   fi
 
   if cat -- "$file_name" | unicode-show >/dev/null ; then
-    ## unicode-show exit code non-zero.
+    ## unicode-show exit code 0.
     printf "%s\n" "$0: ERROR: Failed to find unicode using 'unicode-show' (stdin check) in file '$file_name'." >&2
     exit 1
   fi
-  ## unicode-show exit code 0.
+  ## unicode-show exit code non-zero.
 
   ## 'stcatn' should sanitize. Therefore 'unicode-show' should not find any unicode and exit 0.
   ## Check if there is a non-zero exit code in this pipe, because if so, that's a bug.
   if ! stcatn "$file_name" | unicode-show >/dev/null ; then
-    ## unicode-show exit code 0.
+    ## unicode-show exit code non-zero.
     printf "%s\n" "$0: ERROR: Failed to sanitize string using 'stcatn' in file '$file_name'." >&2
     exit 1
   fi
-  ## unicode-show non-zero exit code.
+  ## unicode-show exit code 0.
 
   if ! cat -- "$file_name" | sanitize-string nolimit >/dev/null ; then
-    ## unicode-show exit code 0.
+    ## sanitize-string exit code non-zero.
     printf "%s\n" "$0: ERROR: Failed to sanitize string using 'sanitize-string' (stdin check) in file '$file_name'." >&2
     exit 1
   fi
@@ -83,7 +83,7 @@ process_file() {
   file_content="$(cat -- "$file_name")"
 
   if ! sanitize-string nolimit "$file_content" >/dev/null ; then
-    ## unicode-show exit code 0.
+    ## sanitize-string exit code non-zero.
     printf "%s\n" "$0: ERROR: Failed to sanitize string using 'sanitize-string' (command check) in file '$file_name'." >&2
     exit 1
   fi
@@ -97,6 +97,7 @@ $0: ERROR: Folder '$HOME/trojan-source' missing. To get it:
 
 cd ~
 git clone git@github.com:nickboucher/trojan-source.git" >&2
+  exit 1
 fi
 
 ## Creates files:


### PR DESCRIPTION
## Summary
This PR corrects misleading comments in the unicode-testscript that incorrectly described exit codes, and adds a missing `exit 1` statement to ensure proper error handling when the trojan-source repository is not found.

## Key Changes
- **Fixed comment accuracy**: Corrected 5 comments that had inverted or incorrect descriptions of `unicode-show` and `sanitize-string` exit codes to match the actual conditional logic
  - Lines 61, 65: Swapped comments describing unicode-show exit codes in the first validation block
  - Line 70: Corrected comment from "unicode-show exit code non-zero" to "unicode-show exit code 0"
  - Line 76: Corrected comment from "unicode-show exit code 0" to "sanitize-string exit code non-zero"
  - Line 86: Corrected comment from "unicode-show exit code 0" to "sanitize-string exit code non-zero"
- **Added missing exit statement**: Added `exit 1` after the error message when the trojan-source folder is missing (line 100), ensuring the script terminates with an error code instead of continuing execution

## Implementation Details
The comments were misleading because they described the opposite of what the conditional statements actually checked. The exit code was missing in the folder validation check, which could allow the script to continue despite a critical dependency being unavailable.

https://claude.ai/code/session_01PfZGFapQ3TpfQYu7tUFYUx