### PR TITLE
Fix typo in grep-find-unicode-wrapper error message

### DIFF
--- a/usr/bin/grep-find-unicode-wrapper
+++ b/usr/bin/grep-find-unicode-wrapper
@@ -16,7 +16,7 @@ check_grep_status() {
   elif [ "$1" = "1" ]; then
     true "$0: INFO: No match."
   else
-    printf '%s\n' "$0: ERROR: grep (syntax?) error! Exiting with code code '$1'." >&2
+    printf '%s\n' "$0: ERROR: grep (syntax?) error! Exiting with code '$1'." >&2
     exit "$1"
   fi
 }


### PR DESCRIPTION
## Summary
Fixed a duplicate word typo in the error message output by the grep-find-unicode-wrapper script.

## Changes
- Removed duplicate "code" word in the grep error message
  - Changed: `"$0: ERROR: grep (syntax?) error! Exiting with code code '$1'."`
  - To: `"$0: ERROR: grep (syntax?) error! Exiting with code '$1'."`

## Details
The error message displayed when grep encounters a syntax error or other failure contained a duplicated word ("code code"). This fix removes the redundant word to produce a grammatically correct error message that users will see when the script exits with a non-zero, non-one status code.

https://claude.ai/code/session_01BXLzzpcfoFQvHLgNs23RvL