### PR TITLE
Enhance password validation warnings when disabling autologin

### DIFF
--- a/usr/sbin/autologinchange
+++ b/usr/sbin/autologinchange
@@ -294,6 +294,7 @@ cli_disable_autologin() {
          exit 0
        fi
        disable_sysmaint_autologin
+       warn_on_unusable_password 'sysmaint'
        exit 0
    fi
 
@@ -304,13 +305,21 @@ cli_disable_autologin() {
    fi
 
    disable_autologin "${user}"
+   warn_on_unusable_password "${user}"
 }
 
-warn_on_empty_user_password() {
-   if [ -z "$(get_clean_pass "$1")" ]; then
-      printf '%s\n' "${red}WARNING:${nocolor} Account '$1' has no password set." >&2
-      printf '%s\n' "Users can log into this account knowing only the username." >&2
-      printf '%s\n' "You can use the 'pwchange' utility to change this." >&2
+warn_on_unusable_password() {
+   local user
+   user="$1"
+   if is_pass_locked "${user}" || is_pass_disabled "${user}"; then
+      printf '%s\n' "${red}WARNING:${nocolor} Account '${user}' has a locked or disabled password." >&2
+      printf '%s\n' "You will NOT be able to log in manually to this account." >&2
+      printf '%s\n' "You can use the 'pwchange' utility to set a password." >&2
+      printf '%s\n' "See https://www.kicksecure.com/wiki/Login for more information." >&2
+   elif [ -z "$(get_clean_pass "${user}")" ]; then
+      printf '%s\n' "${red}WARNING:${nocolor} Account '${user}' has no password set." >&2
+      printf '%s\n' "Anyone can log into this account knowing only the username." >&2
+      printf '%s\n' "You can use the 'pwchange' utility to set a password." >&2
       printf '%s\n' "See https://www.kicksecure.com/wiki/Login for more information." >&2
    fi
 }
@@ -339,7 +348,7 @@ autologinchange() {
       if [ "${disable_yn,,}" = 'y' ]; then
          disable_autologin "${user}"
          printf '%s\n' "SUCCESS: Autologin for account '$user' disabled." >&2
-         warn_on_empty_user_password "$user"
+         warn_on_unusable_password "$user"
       else
          printf '%s\n' "CANCELLED disabling autologin for account '$user'." >&2
       fi
@@ -352,7 +361,7 @@ autologinchange() {
          if [ "${disable_yn,,}" = 'y' ]; then
             disable_sysmaint_autologin
             printf '%s\n' "SUCCESS: Autologin for account 'sysmaint' disabled." >&2
-            warn_on_empty_user_password 'sysmaint'
+            warn_on_unusable_password 'sysmaint'
          else
             printf '%s\n' "CANCELLED disabling autologin for account 'sysmaint'." >&2
          fi


### PR DESCRIPTION
## Summary
Renamed and enhanced the password validation warning function to provide more comprehensive feedback when disabling autologin for user accounts. The function now checks for locked or disabled passwords in addition to empty passwords, and provides more accurate messaging based on the actual password state.

## Key Changes
- Renamed `warn_on_empty_user_password()` to `warn_on_unusable_password()` to better reflect its expanded functionality
- Enhanced the function to detect and warn about locked or disabled passwords using `is_pass_locked()` and `is_pass_disabled()` checks
- Updated warning messages to be more specific:
  - For locked/disabled passwords: warns that manual login will NOT be possible and suggests using 'pwchange' to set a password
  - For empty passwords: clarifies that "anyone" can log in (changed from "users") and suggests setting a password
- Added calls to `warn_on_unusable_password()` in `cli_disable_autologin()` function for both regular users and sysmaint account
- Updated all function call sites to use the new function name

## Implementation Details
- The function now uses a conditional structure to check password states in order of severity (locked/disabled first, then empty)
- All warning messages include a reference to the Kicksecure wiki for additional information
- The warning is now consistently applied whenever autologin is disabled, providing users with important security information about the account's password state

https://claude.ai/code/session_01NAtpA8bBuvZfeu1PeytGRs